### PR TITLE
fix: exibe avatar padrão na página de perfil e corrige verificação da imagem de perfil

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -29,10 +29,18 @@ class ProfileController extends Controller
                 Rule::unique('users')->ignore($user->id),
             ],
             'password' => ['nullable', 'string', 'min:8'],
+            'profile_photo' => ['nullable', 'image', 'max:2048'], // max 2MB
         ]);
-
+        
+        if ($request->hasFile('profile_photo')) {
+            $path = $request->file('profile_photo')->store('profile_photos', 'public');
+            $user->profile_photo_path = $path;
+        }
+        
         $user->name = $validated['name'];
         $user->email = $validated['email'];
+
+        
 
         if (!empty($validated['password'])) {
             $user->password = Hash::make($validated['password']);

--- a/database/migrations/2025_04_04_053138_add_profile_photo_to_users_table.php
+++ b/database/migrations/2025_04_04_053138_add_profile_photo_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('profile_photo_path')->nullable()->after('password');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('profile_photo_path');
+        });
+    }
+
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,10 +7,29 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 dark:text-gray-100">
-                    {{ __("You're logged in!") }}
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+
+                {{-- Exibir imagem de perfil --}}
+                @php
+                    $user = auth()->user();
+                    $photoPath = $user->profile_photo_path;
+                    $hasPhoto = !empty($photoPath) && $photoPath !== 'null';
+                @endphp
+
+                <div class="mt-6 mb-4">
+                    <img src="{{ $hasPhoto
+                                ? asset('storage/' . $photoPath)
+                                : 'https://ui-avatars.com/api/?name=' . urlencode($user->name) . '&background=CCCCCC&color=333333&size=96' }}"
+                        alt="Foto de perfil"
+                        class="rounded-full object-cover border border-gray-300 dark:border-gray-700 shadow"
+                        style="width: 96px; height: 96px; max-width: 96px; max-height: 96px;" />
                 </div>
+
+                {{-- Mensagem de boas-vindas --}}
+                <p class="text-gray-700 dark:text-gray-300">
+                    Você está logado como <strong>{{ $user->name }}</strong>.
+                </p>
+
             </div>
         </div>
     </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -13,9 +13,31 @@
         @csrf
     </form>
 
-    <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('profile.update') }}" enctype="multipart/form-data" class="mt-6 space-y-6">
         @csrf
         @method('patch')
+
+        @php
+            $photoPath = $user->profile_photo_path ?? null;
+            $hasPhoto = !empty($photoPath) && $photoPath !== 'null';
+        @endphp
+
+
+        <div class="mt-6 mb-4">
+            <img src="{{ $hasPhoto
+                        ? asset('storage/' . $photoPath)
+                        : 'https://ui-avatars.com/api/?name=' . urlencode($user->name) . '&background=CCCCCC&color=333333&size=96' }}"
+                alt="Foto de perfil"
+                class="rounded-full object-cover border border-gray-300 dark:border-gray-700 shadow"
+                style="width: 96px; height: 96px; max-width: 96px; max-height: 96px;" />
+        </div>
+
+
+        <div>
+            <x-input-label for="profile_photo" :value="__('Profile Photo')" />
+            <input id="profile_photo" name="profile_photo" type="file" class="mt-1 block w-full" accept="image/*">
+            <x-input-error class="mt-2" :messages="$errors->get('profile_photo')" />
+        </div>
 
         <div>
             <x-input-label for="name" :value="__('Name')" />


### PR DESCRIPTION
Este PR implementa e refina a funcionalidade de imagem de perfil dos usuários, com melhorias visuais, funcionais e de fallback.

### Funcionalidades incluídas:
- Upload de imagem (validação, armazenamento e exibição)
- Exibição da imagem de perfil na página de dashboard e perfil
- Fallback para avatar gerado por ui-avatars.com com cor cinza (`background=CCCCCC`)
- Verificação robusta do caminho da imagem (`profile_photo_path`) para evitar erros
- Estilização com Tailwind (96x96px, arredondada, sombra e borda)
- Alinhamento à esquerda para consistência visual
- Permite cadastro e edição de perfil sem imagem obrigatória

Este é um dos diferenciais implementados no teste técnico com Laravel 10.